### PR TITLE
Make sure ARM9 memory reads only read ITCM/DTCM when load mode is not set

### DIFF
--- a/src/cp15.h
+++ b/src/cp15.h
@@ -38,6 +38,8 @@ class Cp15
         uint32_t getDtcmAddr()      { return dtcmAddr;      }
         uint32_t getDtcmSize()      { return dtcmSize;      }
         uint32_t getItcmSize()      { return itcmSize;      }
+        bool getDtcmLoadMode()      { return ctrlReg & (1 << 17); }
+        bool getItcmLoadMode()      { return ctrlReg & (1 << 19); }
 
     private:
         Core *core;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -62,12 +62,12 @@ template <typename T> T Memory::read(bool cpu, uint32_t address)
     if (cpu == 0) // ARM9
     {
         // Get a pointer to the ARM9 memory mapped to the given address
-        if (core->cp15.getItcmEnabled() && address < core->cp15.getItcmSize()) // Instruction TCM
+        if (core->cp15.getItcmEnabled() && address < core->cp15.getItcmSize() && !core->cp15.getItcmLoadMode()) // Instruction TCM
         {
             data = &instrTcm[address & 0x7FFF];
         }
         else if (core->cp15.getDtcmEnabled() && address >= core->cp15.getDtcmAddr() &&
-            address < core->cp15.getDtcmAddr() + core->cp15.getDtcmSize()) // Data TCM
+            address < core->cp15.getDtcmAddr() + core->cp15.getDtcmSize() && !core->cp15.getDtcmLoadMode()) // Data TCM
         {
             data = &dataTcm[(address - core->cp15.getDtcmAddr()) & 0x3FFF];
         }


### PR DESCRIPTION
There's a test in rockwrestler https://github.com/RockPolish/rockwrestler/blob/master/src9/tests/tcm.cpp (starting from test 0x010) which fails on NooDS because arm9 memory reads don't account for dtcm/itcm load mode in the control register. When load mode is set tcm becomes write only. Now the test should pass