### PR TITLE
Added save type selector for vita

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bios9.bin
 firmware.bin
 gba_bios.bin
 sd.img
+.vscode
+.project
+.history

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -35,8 +35,9 @@ eboot.bin: $(NAME).velf
 param.sfo:
 	$(MKSFOEX) -s TITLE_ID="$(TITLEID)" "$(APPNAME)" $@
 
+# Removed -s because it gives error
 $(NAME).velf: $(NAME).elf
-	$(ELFCREATE) -s $< $@
+	$(ELFCREATE) $< $@
 
 $(NAME).elf: $(OFILES)
 	$(CXX) $^ $(LIBS) -o $@


### PR DESCRIPTION
It adds a save type selector when selecting a ROM. Depending if it's a DS or GBA ROM it will show the save types according to the system. It will also display a "Skip" option so don't overwrite your save if you have one.

I have tried to detect if there is a save file present but the core doesn't let me (It's in private!) and my attempt (commented code) didn't work.