### PR TITLE
Update resource/info files for wxWidgets hiDPI

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -32,8 +32,8 @@
     <string>Licensed under GPLv3</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
-    <key>NSRequiresAquaSystemAppearance</key>
-    <true/>
+    <key>NSPrincipalClass</key>
+    <string>wxNSApplication</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app requires microphone access to emulate the DS microphone.</string>
     <key>CFBundleDocumentTypes</key>

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(BUILD)/%.o: %.cpp $(HFILES) $(BUILD)
 	g++ -c -o $@ $(ARGS) $(INCLUDES) $<
 
 $(BUILD)/icon-windows.o:
-	windres icon/icon-windows.rc $@
+	windres $(shell wx-config-static --cppflags) icon/icon-windows.rc $@
 
 $(BUILD):
 	for dir in $(SOURCES); \

--- a/icon/icon-windows.rc
+++ b/icon/icon-windows.rc
@@ -1,1 +1,5 @@
+#define wxUSE_RC_MANIFEST 1
+#define wxUSE_DPI_AWARE_MANIFEST 1
+#include <wx/msw/wx.rc>
+
 NooDS ICON "icon-windows.ico"


### PR DESCRIPTION
* Include the wxMSW manifest on Windows, which enables high DPI support, along with themed controls in dialogs
* Set NSPrincipalClass on macOS to wxNSApplication, which according to the documentation is needed for correct high DPI support
* Remove NSRequiresAquaSystemAppearance key which was used to force light mode on macOS as wxWidgets 3.0 didn't properly support dark mode