### PR TITLE
Add "Show On-Screen Buttons" as a toggle in General Settings

### DIFF
--- a/src/android/cpp/interface.cpp
+++ b/src/android/cpp/interface.cpp
@@ -34,6 +34,7 @@ int showFpsCounter = 0;
 int buttonScale = 5;
 int buttonSpacing = 10;
 int vibrateStrength = 1;
+int showButtons = 1;
 int keyBinds[12] = {};
 
 std::string ndsPath = "", gbaPath = "";
@@ -92,6 +93,7 @@ extern "C" JNIEXPORT jboolean JNICALL Java_com_hydra_noods_FileBrowser_loadSetti
         Setting("screenFilter",    &screenFilter,    false),
         Setting("micEnable",       &micEnable,       false),
         Setting("showFpsCounter",  &showFpsCounter,  false),
+        Setting("showButtons",     &showButtons,     false),
         Setting("buttonScale",     &buttonScale,     false),
         Setting("buttonSpacing",   &buttonSpacing,   false),
         Setting("vibrateStrength", &vibrateStrength, false),
@@ -395,6 +397,11 @@ extern "C" JNIEXPORT jint JNICALL Java_com_hydra_noods_SettingsMenu_getShowFpsCo
     return showFpsCounter;
 }
 
+extern "C" JNIEXPORT jint JNICALL Java_com_hydra_noods_SettingsMenu_getShowButtons(JNIEnv* env, jobject obj)
+{
+    return showButtons;
+}
+
 extern "C" JNIEXPORT jint JNICALL Java_com_hydra_noods_SettingsMenu_getButtonScale(JNIEnv* env, jobject obj)
 {
     return buttonScale;
@@ -483,6 +490,11 @@ extern "C" JNIEXPORT void JNICALL Java_com_hydra_noods_SettingsMenu_setMicEnable
 extern "C" JNIEXPORT void JNICALL Java_com_hydra_noods_SettingsMenu_setShowFpsCounter(JNIEnv* env, jobject obj, jint value)
 {
     showFpsCounter = value;
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_hydra_noods_SettingsMenu_setShowButtons(JNIEnv* env, jobject obj, jint value)
+{
+    showButtons = value;
 }
 
 extern "C" JNIEXPORT void JNICALL Java_com_hydra_noods_SettingsMenu_setButtonScale(JNIEnv* env, jobject obj, jint value)

--- a/src/android/java/com/hydra/noods/NooActivity.java
+++ b/src/android/java/com/hydra/noods/NooActivity.java
@@ -142,7 +142,9 @@ public class NooActivity extends AppCompatActivity
         switch (item.getItemId())
         {
             case R.id.controls_action:
+
                 // Toggle hiding the on-screen buttons
+
                 if (showingButtons = !showingButtons)
                 {
                     for (int i = 0; i < 6; i++)
@@ -154,6 +156,8 @@ public class NooActivity extends AppCompatActivity
                         layout.removeView(buttons[i]);
                 }
                 return true;
+                
+                
 
             case R.id.save_action:
                 final boolean gba = isGbaMode();
@@ -321,6 +325,14 @@ public class NooActivity extends AppCompatActivity
             for (int i = 0; i < 6; i++)
                 layout.addView(buttons[i]);
             initButtons = false;
+        }
+
+        // Remove buttons from layout if disabled
+        if (SettingsMenu.getShowButtons() == 0)
+        {
+            for (int i = 0; i < 6; i++)
+                layout.removeView(buttons[i]);
+            showingButtons = false;
         }
     }
 

--- a/src/android/java/com/hydra/noods/SettingsMenu.java
+++ b/src/android/java/com/hydra/noods/SettingsMenu.java
@@ -94,6 +94,7 @@ public class SettingsMenu extends AppCompatActivity
         editor.putBoolean("screen_filter", (getScreenFilter() == 0) ? false : true);
         editor.putBoolean("mic_enable", (getMicEnable() == 0) ? false : true);
         editor.putBoolean("show_fps_counter", (getShowFpsCounter() == 0) ? false : true);
+        editor.putBoolean("show_buttons", (getShowButtons() == 0) ? false : true);
         editor.putInt("button_scale", getButtonScale());
         editor.putInt("button_spacing", getButtonSpacing());
         editor.putInt("vibrate_strength", getVibrateStrength());
@@ -125,6 +126,7 @@ public class SettingsMenu extends AppCompatActivity
         setScreenFilter(prefs.getBoolean("screen_filter", true) ? 1 : 0);
         setMicEnable(prefs.getBoolean("mic_enable", false) ? 1 : 0);
         setShowFpsCounter(prefs.getBoolean("show_fps_counter", false) ? 1 : 0);
+        setShowButtons(prefs.getBoolean("show_buttons", false) ? 1 : 0);
         setButtonScale(prefs.getInt("button_scale", 5));
         setButtonSpacing(prefs.getInt("button_spacing", 10));
         setVibrateStrength(prefs.getInt("vibrate_strength", 1));
@@ -149,6 +151,7 @@ public class SettingsMenu extends AppCompatActivity
     public static native int getScreenFilter();
     public static native int getMicEnable();
     public static native int getShowFpsCounter();
+    public static native int getShowButtons();
     public static native int getButtonScale();
     public static native int getButtonSpacing();
     public static native int getVibrateStrength();
@@ -167,6 +170,7 @@ public class SettingsMenu extends AppCompatActivity
     public static native void setScreenFilter(int value);
     public static native void setMicEnable(int value);
     public static native void setShowFpsCounter(int value);
+    public static native void setShowButtons(int value);
     public static native void setButtonScale(int value);
     public static native void setButtonSpacing(int value);
     public static native void setVibrateStrength(int value);

--- a/src/android/res/xml/settings.xml
+++ b/src/android/res/xml/settings.xml
@@ -58,6 +58,13 @@
             app:key="show_fps_counter"
             app:title="Show FPS Counter"
             app:iconSpaceReserved="false"
+            app:allowDividerAbove="true"
+            app:allowDividerBelow="true" />
+
+        <SwitchPreferenceCompat
+            app:key="show_buttons"
+            app:title="Show On-Screen Buttons"
+            app:iconSpaceReserved="false"
             app:allowDividerAbove="true" />
     </PreferenceCategory>
 


### PR DESCRIPTION
Did some modifications to source code for a _On-Screen Buttons_ toggle within the General Settings menu. This toggle enables/disables the On-Screen Buttons on the Android touch screen and saves the setting between sessions for the user's convenience.

 
![image](https://github.com/Hydr8gon/NooDS/assets/166251435/4be082fd-24fd-4d38-b140-42e42792ab7c)
